### PR TITLE
Auto create title and notes when generated a release

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -110,7 +110,9 @@ jobs:
         gh release create
         '${{ github.ref_name }}'
         --repo '${{ github.repository }}'
-        --notes ""
+        --generate-notes
+        --title "${{ github.ref_name }}"
+        --latest
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Whenever this package it released, these paramters will set the title of the github release to the tag and auto-generate release notes. 