### PR TITLE
Raise DeprecationWarning if TketOptimizations.GlobalisePhasedX is set.

### DIFF
--- a/compiler_config/config.py
+++ b/compiler_config/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import re
 import sys
+import warnings
 from enum import Enum, Flag, IntEnum, auto
 from typing import List, Optional
 
@@ -351,6 +352,19 @@ class Tket(OptimizationConfig):
     def minimum(self):
         self.tket_optimizations = TketOptimizations.DefaultMappingPass
         return self
+
+    def __setattr__(self, attr, value):
+        if (
+            isinstance(value, TketOptimizations)
+            and TketOptimizations.GlobalisePhasedX in value
+        ):
+            warnings.warn(
+                "Tket flag TketOptimizations.GlobalisePhasedX has been "
+                "deprecated and will be removed in the next version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        super().__setattr__(attr, value)
 
     def __contains__(self, item):
         if isinstance(item, TketOptimizations) and item in self.tket_optimizations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "compiler-config"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["jamie <jfriel@oxfordquantumcircuits.com>"]
 readme = "README.md"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from compiler_config.config import (
     QiskitOptimizations,
     QuantumResultsFormat,
     ResultsFormatting,
+    Tket,
     TketOptimizations,
 )
 
@@ -171,3 +172,14 @@ def test_json_version_compatibility_full(version):
     )
     assert deserialised_conf.optimizations.qiskit_optimizations == QiskitOptimizations.Empty
     assert deserialised_conf.optimizations.tket_optimizations == TketOptimizations.One
+
+
+@pytest.mark.parametrize("flag", [to for to in TketOptimizations])
+def test_tket_flags(flag):
+    tket = None
+    if flag == TketOptimizations.GlobalisePhasedX:
+        with pytest.warns(DeprecationWarning):
+            tket = Tket(tket_optimization=flag)
+    else:
+        tket = Tket(tket_optimization=flag)
+    assert flag in tket


### PR DESCRIPTION
Tket has deprecated the globalised phased X pass. This PR adds a warning for users setting the flag to use the deprecated feature. In a future version the flag will be removed as an option.