### PR TITLE
Update README to clarify dependency and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # For now everyone gets added to all PRs by default. Fine while the PR velocity is small, we'll change if
 # necessary as time goes on.
-* @keriksson-rosenqvist @owen-oqc @hamidelmaazouz @bgsach @daria-oqc @lcauser-oqc @alillistone-OQC
+* @keriksson-rosenqvist-oqc @oarnold-oqc @helmaazouz-oqc @bsach-oqc @dvanhende-oqc @lcauser-oqc @alillistone-OQC

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # compiler-config
 
 OQC's task level compiler configuration. The compiler-config package is an internal dependency of [QAT](https://github.com/oqc-community/qat) 
-(OQC's compiler and runtime) and will soon be adopted as a dependency of our QCaaS (Quantum Computing as a Service) client. *End users should not need to interact with this package except via QAT or QCAAS client.*
+(OQC's compiler and runtime) and a dependency of our QCaaS (Quantum Computing as a Service) client. *End users should not need to interact with this package except via QAT or QCAAS client.*
 
 #### Licence
 


### PR DESCRIPTION
- Update README to clarify that compiler-config is now a QCAAS client dependency
- Update CODEOWNERS