### PR TITLE
Change to `Experimental` to print qubit indices.

### DIFF
--- a/compiler_config/config.py
+++ b/compiler_config/config.py
@@ -226,7 +226,7 @@ class CompilerConfig:
         repeats=None,
         repetition_period=None,
         results_format: QuantumResultsFormat = None,
-        metrics=MetricsType.Default,
+        metrics=MetricsType.Experimental,
         active_calibrations=None,
         optimizations: "OptimizationConfig" = None,
         error_mitigation: ErrorMitigationConfig = None,


### PR DESCRIPTION
The default metrics in `CompilerConfig` do not include the physical qubit indices. Changed this in this PR.

This is related to ticket 666.