### PR TITLE
More fixes to github release workflow

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -136,6 +136,7 @@ jobs:
       url: https://pypi.org/p/qat-config  # Replace <package-name> with your PyPI project name
     permissions:
       id-token: write
+      contents: write
 
     steps:
     - name: Download all the dists

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -149,6 +149,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verbose: true
+        skip-existing: true
 
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.0.1


### PR DESCRIPTION
1. Give the publish-to-pypi job permission to create a GitHub release.
2. Skip the upload to pypi if the version already exists.