### PR TITLE
Release notes and dependabot labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - ignore-on-release
     groups:
       github-actions:
         patterns:
@@ -15,6 +17,8 @@ updates:
     versioning-strategy: lockfile-only
     schedule:
       interval: "daily"
+    labels:
+      - ignore-on-release
     groups:
       security-updates:
         applies-to: security-updates

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - ignore-on-release
+      - ignore-for-release
     groups:
       github-actions:
         patterns:
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - ignore-on-release
+      - ignore-for-release
     groups:
       security-updates:
         applies-to: security-updates

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🛠 Breaking Changes 
+      labels:
+        - breaking-change
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: ⚙️ DevOps
+      labels:
+        - devops
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: 🧪 Experimental
+      labels:
+        - experimental
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This PR add the standard release notes format that we have in QAT. 

It also ensure dependabot updates do not appear in the release notes