### PR TITLE
COMPILER-992: Add pre_selection and post_selection options to CompilerConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-merge-conflict
         stages: [pre-commit, manual]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.7
     hooks:
       # Run the linter (with auto-fix enabled for safe fixes).
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v0.14.10
     hooks:
       # Run the linter (with auto-fix enabled for safe fixes).
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
       # Run the formatter.
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
     hooks:
-      # Run the linter.
+      # Run the linter (with auto-fix enabled for safe fixes).
       - id: ruff
+        args: ["--fix"]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/python-poetry/poetry

--- a/compiler_config/config.py
+++ b/compiler_config/config.py
@@ -231,6 +231,8 @@ class CompilerConfig:
         optimizations: "OptimizationConfig" = None,
         error_mitigation: ErrorMitigationConfig = None,
         passive_reset_time: float = None,
+        post_selection:bool = False,
+        pre_selection: bool = False,
     ):
         self.repeats: Optional[int] = repeats
         self.repetition_period: Optional[float] = repetition_period
@@ -240,6 +242,8 @@ class CompilerConfig:
         self.active_calibrations: List[CalibrationArguments] = active_calibrations or []
         self.optimizations: Optional[OptimizationConfig] = optimizations
         self.error_mitigation: Optional[ErrorMitigationConfig] = error_mitigation
+        self.pre_selection: bool = pre_selection
+        self.post_selection: bool = post_selection
 
         if repetition_period:
             warnings.warn(

--- a/compiler_config/config.py
+++ b/compiler_config/config.py
@@ -231,7 +231,7 @@ class CompilerConfig:
         optimizations: "OptimizationConfig" = None,
         error_mitigation: ErrorMitigationConfig = None,
         passive_reset_time: float = None,
-        post_selection:bool = False,
+        post_selection: bool = False,
         pre_selection: bool = False,
     ):
         self.repeats: Optional[int] = repeats

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,6 @@ def get_contents(file_path):
 # Parameterized fixture for each JSON template file in the templates directory. In other words, any test that
 # uses this fixture is tested on all files in the list.
 @pytest.fixture(params=template_dir.glob("*.json"))
-def json_template(request):
+def json_template_path(request):
     """Yields the name of each JSON template file in the templates directory."""
     return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 SUPPORTED_CONFIG_VERSIONS = ["v02", "v01", "v1"]
 
 
@@ -7,19 +9,24 @@ class TestType:
     pass
 
 
-tests_dir = None
-
-
-def pytest_configure(config):
-    global tests_dir
-    tests_dir = config.rootpath / "tests"
+# Derive tests_dir from __file__
+tests_dir = Path(__file__).parent
+template_dir = tests_dir / "serialised_compiler_config_templates"
 
 
 def _get_json_path(file_name):
-    return Path(tests_dir, "serialised_compiler_config_templates", file_name)
+    return template_dir / file_name
 
 
 def get_contents(file_path):
     """Get Json from a file."""
     with open(_get_json_path(file_path)) as ifile:
         return ifile.read()
+
+
+# Parameterized fixture for each JSON template file in the templates directory. In other words, any test that
+# uses this fixture is tested on all files in the list.
+@pytest.fixture(params=template_dir.glob("*.json"))
+def json_template(request):
+    """Yields the name of each JSON template file in the templates directory."""
+    return request.param

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,6 +77,10 @@ def test_pre_post_selection_serialisation(pre_select, post_select):
 
 
 def test_pre_post_selection_backwards_compatibility(json_template):
+    """
+    Tests that all legacy files are readable and that the defaults for pre and post selection are correctly
+    qpplied.
+    """
     config = CompilerConfig.create_from_json(get_contents(json_template))
     assert config.pre_selection is False
     assert config.post_selection is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,10 @@ def test_specific_config_optimizations():
         == second_conf.optimizations.qiskit_optimizations
     )
 
-@pytest.mark.parametrize("pre_select, post_select", [(True, True), (True, False), (False, True), (False, False)])
+
+@pytest.mark.parametrize(
+    "pre_select, post_select", [(True, True), (True, False), (False, True), (False, False)]
+)
 def test_pre_post_selection_serialisation(pre_select, post_select):
     """
     Test that the pre_selection and post_selection fields are correctly serialised and deserialised
@@ -65,8 +68,8 @@ def test_pre_post_selection_serialisation(pre_select, post_select):
     """
     local_config = CompilerConfig(pre_selection=pre_select, post_selection=post_select)
     serialized_data = local_config.to_json()
-    assert f'"pre_selection":' in serialized_data
-    assert f'"post_selection":' in serialized_data
+    assert '"pre_selection":' in serialized_data
+    assert '"post_selection":' in serialized_data
 
     decode_config = CompilerConfig.create_from_json(serialized_data)
     assert decode_config.pre_selection == pre_select

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
-
+from pathlib import Path
 from sys import __loader__
 
 import pytest
@@ -60,11 +60,13 @@ def test_specific_config_optimizations():
 @pytest.mark.parametrize(
     "pre_select, post_select", [(True, True), (True, False), (False, True), (False, False)]
 )
-def test_pre_post_selection_serialisation(pre_select, post_select):
+def test_pre_post_selection_serialisation(pre_select: bool, post_select: bool):
     """
     Test that the pre_selection and post_selection fields are correctly serialised and deserialised
     in the CompilerConfig object. Ensures that both True and False values for these fields are
     preserved through the serialisation-deserialisation process.
+    :param pre_select:  Boolean value for the pre_selection field to test.
+    :param post_select:  Boolean value for the post_selection field to test.
     """
     local_config = CompilerConfig(pre_selection=pre_select, post_selection=post_select)
     serialized_data = local_config.to_json()
@@ -76,12 +78,13 @@ def test_pre_post_selection_serialisation(pre_select, post_select):
     assert decode_config.post_selection == post_select
 
 
-def test_pre_post_selection_backwards_compatibility(json_template):
+def test_pre_post_selection_backwards_compatibility(json_template_path: Path):
     """
     Tests that all legacy files are readable and that the defaults for pre and post selection are correctly
     qpplied.
+    :param json_template: Fixture that provides the path to each JSON template file in the templates directory.
     """
-    config = CompilerConfig.create_from_json(get_contents(json_template))
+    config = CompilerConfig.create_from_json(get_contents(json_template_path))
     assert config.pre_selection is False
     assert config.post_selection is False
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,22 @@ def test_specific_config_optimizations():
         == second_conf.optimizations.qiskit_optimizations
     )
 
+@pytest.mark.parametrize("pre_select, post_select", [(True, True), (True, False), (False, True), (False, False)])
+def test_pre_post_selection_serialisation(pre_select, post_select):
+    """
+    Test that the pre_selection and post_selection fields are correctly serialised and deserialised
+    in the CompilerConfig object. Ensures that both True and False values for these fields are
+    preserved through the serialisation-deserialisation process.
+    """
+    local_config = CompilerConfig(pre_selection=pre_select, post_selection=post_select)
+    serialized_data = local_config.to_json()
+    assert f'"pre_selection":' in serialized_data
+    assert f'"post_selection":' in serialized_data
+
+    decode_config = CompilerConfig.create_from_json(serialized_data)
+    assert decode_config.pre_selection == pre_select
+    assert decode_config.post_selection == post_select
+
 
 def test_all_config_optimizations():
     def get_subclasses(object):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,12 @@ def test_pre_post_selection_serialisation(pre_select, post_select):
     assert decode_config.post_selection == post_select
 
 
+def test_pre_post_selection_backwards_compatibility(json_template):
+    config = CompilerConfig.create_from_json(get_contents(json_template))
+    assert config.pre_selection is False
+    assert config.post_selection is False
+
+
 def test_all_config_optimizations():
     def get_subclasses(object):
         subclasses = []


### PR DESCRIPTION
# Description

This just adds two flags to enable pre- and post-selection functionality in Qat. These are global options, pre-qubit operation is handled in the hw config.

# Testing

A new test has been added to check that each flag is correctly serialised and deserialised (necessary because we use
a custom JSON serialiser which is somewhat opaque.)